### PR TITLE
Report local VCS repositories

### DIFF
--- a/src/actors/upgrade/common/list_all_files/_actor.yaml
+++ b/src/actors/upgrade/common/list_all_files/_actor.yaml
@@ -1,0 +1,9 @@
+outputs:
+- name: all_local_files
+  type:
+    name: StringList
+description: |
+  List all local files.
+execute:
+  script-file: check
+  executable: /usr/bin/python

--- a/src/actors/upgrade/common/list_all_files/check
+++ b/src/actors/upgrade/common/list_all_files/check
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+from subprocess import Popen, PIPE
+import json
+import sys
+
+
+def log_error(errmsg):
+    """Log error on stderr."""
+    sys.stderr.write("%s\n" % errmsg)
+
+
+if __name__ == '__main__':
+    # NOTE: expected dirs without whitespaces
+    cmd_local_mnt = "df --local -P | sed 1d | awk '{print $NF}'"
+    cmd_file_list = "find $i -xdev -print"
+    cmd = "for i in $(%s);do %s; done |sort |uniq" % (cmd_local_mnt, cmd_file_list)
+
+    p = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE)
+    p_out, p_err = p.communicate()
+    if p.returncode != 0:
+        log_error("Error during generating of file list: %s" % p_err)
+        sys.exit(p.returncode)
+
+    files = p_out.splitlines()
+    out = {"all_local_files": [{"value": files}]}
+    print(json.dumps(out))

--- a/src/actors/upgrade/vcs_repos/vcs_detection/_actor.yaml
+++ b/src/actors/upgrade/vcs_repos/vcs_detection/_actor.yaml
@@ -1,0 +1,28 @@
+inputs:
+- name: all_local_files
+  type:
+    name: StringList
+
+outputs:
+- name: vcs_repo_git
+  type:
+    name: StringList
+- name: vcs_repo_svn
+  type:
+    name: StringList
+- name: vcs_repo_cvs
+  type:
+    name: StringList
+- name: vcs_repo_bzr
+  type:
+    name: StringList
+- name: vcs_repo_hg
+  type:
+    name: StringList
+
+description: |
+  Find all VCS rpositories including Git, SVN, CVS, BZR and HG.
+execute:
+  script-file: check
+  executable: /usr/bin/python
+...

--- a/src/actors/upgrade/vcs_repos/vcs_detection/check
+++ b/src/actors/upgrade/vcs_repos/vcs_detection/check
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import sys
+import json
+
+
+# API_CANDIDATE
+def load_inputs():
+    "Load all inputs and return dictionary with all input channels."
+    # TODO: create class for work with input API
+    return json.load(sys.stdin) if not sys.stdin.isatty() else {}
+
+
+# API_CANDIDATE
+class OutputBuilder(object):
+    """
+    Provide functionality for work with expected output of actor.
+    """
+
+    def __init__(self):
+        self.channel = {}
+
+    def store_output(self, channel, data):
+        "Store the data into the expected channel"
+        # TODO: Of course, this particular function works just for StringList
+        # now. we should think about more generic solution for use in API.
+        # Or maybe have prepared methods to store specific type of channels:
+        # -- store_stringlist(self, channel, data)
+        # -- store_string(self, channel, data)
+        # -- store_report(self, data)  # in this case, channel is constant!
+        # ....
+        self.channel[channel] = [{"value": data}]
+
+    def dump_output(self):
+        "Generate JSON object."
+        # NOTE: this could be probably removed in future or it can be used
+        # just for debug purposes.
+        return json.dumps(self.channel)
+
+    def print_output(self):
+        "Print generated JSON output on stdout."
+        print(self.dump_output())
+
+
+# API_CANDIDATE
+def log_error(msg):
+    "Log error on stderr."
+    sys.stderr.write("Error: %s\n" % msg)
+
+
+def detect_repo(fname):
+    """
+    Check whether we found VCS repository or not.
+
+    In case we detected repository, return repository type (string). Otherwise
+    return None object.
+    """
+    for repo, suffix in vcs_map.items():
+        if fname.endswith("/%s" % suffix):
+            return repo
+    return None
+
+
+if __name__ == '__main__':
+    IN_LOCAL_FILES = "all_local_files"
+    vcs_map = {"bzr": ".bzr/branch/branch.conf",
+               "hg": ".hg/config",
+               "git": ".git/config",
+               "svn": ".svn/entries",
+               "cvs": "CVS/Root"}
+    inputs = load_inputs()
+    output = OutputBuilder()
+    vcs = {repo: [] for repo in ("bzr", "hg", "git", "svn", "cvs")}
+
+    if IN_LOCAL_FILES not in inputs:
+        log_error("The expected input channel was not found '%s'." % IN_LOCAL_FILES)
+        sys.exit(1)
+
+    for fname in inputs[IN_LOCAL_FILES][0]["value"]:
+        repo = detect_repo(fname)
+        if repo:
+            vcs[repo].append(fname)
+
+    for repo, data in vcs.items():
+        output.store_output("vcs_repo_%s" % repo, data)
+
+    output.print_output()

--- a/src/actors/upgrade/vcs_repos/vcs_group/_actor.yaml
+++ b/src/actors/upgrade/vcs_repos/vcs_group/_actor.yaml
@@ -1,0 +1,11 @@
+outputs:
+- name: check_output
+  type:
+    name: CheckOutput
+description: |
+  Just temporary group actor that links the set of actors providing
+  report message about vcs repositories together.
+group:
+- list_all_files
+- vcs_detection
+- vcs_report

--- a/src/actors/upgrade/vcs_repos/vcs_report/_actor.yaml
+++ b/src/actors/upgrade/vcs_repos/vcs_report/_actor.yaml
@@ -1,0 +1,27 @@
+tags: informational
+inputs:
+- name: vcs_repo_git
+  type:
+    name: StringList
+- name: vcs_repo_svn
+  type:
+    name: StringList
+- name: vcs_repo_cvs
+  type:
+    name: StringList
+- name: vcs_repo_bzr
+  type:
+    name: StringList
+- name: vcs_repo_hg
+  type:
+    name: StringList
+outputs:
+- name: check_output
+  type:
+    name: CheckOutput
+description: |
+  Report found repositories.
+execute:
+  script-file: check
+  executable: /usr/bin/python
+...

--- a/src/actors/upgrade/vcs_repos/vcs_report/check
+++ b/src/actors/upgrade/vcs_repos/vcs_report/check
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import sys
+import json
+
+
+# API_CANDIDATE
+def load_inputs():
+    "Load all inputs and return dictionary with all input channels."
+    # TODO: create class for work with input API
+    return json.load(sys.stdin) if not sys.stdin.isatty() else {}
+
+
+def check_repo(repo_list, repo_type):
+    """
+    Check whether system contains specific VCS repository.
+
+    In case that repo_list is empty, return CheckEntry with status PASS.
+    Otherwise the status is FAIL and append the list of detected repositories
+    as 'params'.
+    """
+    if repo_list:
+        return {
+            'check_actor': 'vcs_report',
+            'check_action': repo_type,
+            'status': 'FAIL',
+            'summary': 'Some %s repositories have been detected.' % repo_type,
+            'params': repo_list
+        }
+    else:
+        return {
+            'check_actor': 'vcs_report',
+            'check_action': repo_type,
+            'status': 'PASS',
+            'summary': 'No %s repository was detected' % repo_type
+        }
+
+
+if __name__ == '__main__':
+    inputs = load_inputs()
+    check_results = []
+    for repo_type in ['bzr', 'hg', 'git', 'svn', 'cvs']:
+        repo_list = inputs['vcs_repo_%s' % repo_type][0]['value']
+        check_results.append(check_repo(repo_list, repo_type))
+
+    # TODO: API...
+    outputs = {'check_output': [{'checks': check_results}]}
+    print(json.dumps(outputs))


### PR DESCRIPTION
# Basic description
The PR contains 3 actors:
 - `upgrade/common/list_all_local_files`: produces list of all local files on the host machine
 - `upgrade/vcs_repo/vcs_detection`:  produces lists of all locally stored VCS repositories (1)
 - `upgrade/vcs_repo/`: produces message for the report actor using `CheckOutput` schema (2)

(1) Includes Git, Bazaar, Mercurial, CVS, SVN. Each type is stored on different output channel for now using generic schema `StringList`. Another option would be produce of one channel VCS repositores using with own JSON schema, but for now I prefer using of more channels.

(2) ~~Requires merge of PR #19 for correct run. Just remember, that report actor and schema will be changed definitely.~~ (merged already)

# Additional info
Added group actor to link all  three actors together. The group actor is supposed to be removed in future when dependencies between actors will be resolved automatically based on expected inputs and outputs.