### PR TITLE
WP generator: execute returns True if command executes succesfully

### DIFF
--- a/src/actors/containerization/services/wordpress/wordpress_generator/wordpress_generator.py
+++ b/src/actors/containerization/services/wordpress/wordpress_generator/wordpress_generator.py
@@ -6,10 +6,12 @@ from subprocess import check_output, CalledProcessError
 
 def _execute(cmd, **kwargs):
     try:
-        return check_output(cmd, shell=True, **kwargs)
+        check_output(cmd, shell=True, **kwargs)
     except CalledProcessError as e:
         sys.stderr.write(str(e)+'\n')
         return None
+
+    return True
 
 
 def build_base_image(version):


### PR DESCRIPTION
change output of _execute because new versions of s2i print to stderr instead of stdout