### PR TITLE
WP generator: use check_call instead of check_output

### DIFF
--- a/src/actors/containerization/services/wordpress/wordpress_generator/wordpress_generator.py
+++ b/src/actors/containerization/services/wordpress/wordpress_generator/wordpress_generator.py
@@ -1,17 +1,17 @@
 import json
 import sys
 import os
-from subprocess import check_output, CalledProcessError
+from subprocess import check_call, CalledProcessError
 
 
 def _execute(cmd, **kwargs):
     try:
-        check_output(cmd, shell=True, **kwargs)
+        rc = check_call(cmd, shell=True, **kwargs)
     except CalledProcessError as e:
         sys.stderr.write(str(e)+'\n')
-        return None
+        rc = e.returncode
 
-    return True
+    return rc
 
 
 def build_base_image(version):
@@ -33,7 +33,7 @@ def build_container(directory, version):
     name = 'wp-'+version
     cmd = 's2i build {directory} wp-base {name}'.format(directory=directory, name=name)
     ret = _execute(cmd)
-    return name if ret else None
+    return name if not ret else None
 
 
 def run_container(name):


### PR DESCRIPTION
change execute function to use check_call and return returncode
using check_output makes no sense in this case since we don't really care about output