### PR TITLE
Python dependencies for CentOS 7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ test:
 install-deps-new:
 	virtualenv -p /usr/bin/python2.7 tut; \
 	. tut/bin/activate; \
+	pip install --upgrade setuptools; \
 	pip install -r requirements_new.txt
 
 # runs tests using new framework

--- a/requirements_new.txt
+++ b/requirements_new.txt
@@ -1,4 +1,5 @@
 ### Additional requirements
 pytest
 pytest-ordering
+funcsigs
 git+https://github.com/leapp-to/leapp


### PR DESCRIPTION
Upgrade setuptools package and add funcsigs package to dependencies to get the new tests working on CentOS 7.