### PR TITLE
Propagate exit code from test

### DIFF
--- a/utils/run_new_pytest.py
+++ b/utils/run_new_pytest.py
@@ -71,4 +71,4 @@ if __name__ == "__main__":
         pytest_cmd += ["--junit-xml={REPORT}".format(REPORT=args.report)]
 
     print(pytest_cmd)
-    subprocess.call(pytest_cmd)
+    exit(subprocess.call(pytest_cmd))


### PR DESCRIPTION
Propagate the exit code from pytest so that the caller knows if the test passed or failed.