### PR TITLE
Use requirement on systemd-conteiner only on relevant system

### DIFF
--- a/leapp-repository.spec
+++ b/leapp-repository.spec
@@ -15,7 +15,9 @@ URL:        https://leapp-to.github.io
 Source0:    https://github.com/leapp-to/leapp-actors/archive/%{gittag}/leapp-actors-%{version}.tar.gz
 BuildArch:  noarch
 Requires:   dnf >= 2.7.5
+%if 0%{?fedora} || 0%{?rhel} > 7
 Requires:   systemd-container
+%endif
 %description
 Repositories for leapp
 


### PR DESCRIPTION
The systemd-container subpackage doesn't exist on RHEL <= 7. On the RHEL 7 system is systemd-spawn part of the systemd RPM that it is always installed so the dependency is not needed here.