### PR TITLE
added leapp.conf to common, containerization and upgrade repos

### DIFF
--- a/repos/common/.leapp/leapp.conf
+++ b/repos/common/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${project:root_dir}
+
+[database]
+path=${project:state_dir}/leapp.db

--- a/repos/containerization/.leapp/leapp.conf
+++ b/repos/containerization/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${project:root_dir}
+
+[database]
+path=${project:state_dir}/leapp.db

--- a/repos/upgrade/.leapp/leapp.conf
+++ b/repos/upgrade/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${project:root_dir}
+
+[database]
+path=${project:state_dir}/leapp.db


### PR DESCRIPTION
Trying to run actor is failing with:

```
$ snactor run --print-output TestActor

Traceback (most recent call last):
  File "/home/tmeszaro/work/github/leapp-actors/tut/bin/snactor", line 11, in <module>
    sys.exit(main())
  File "/home/tmeszaro/work/github/leapp-actors/tut/lib/python2.7/site-packages/leapp/snactor/__init__.py", line 68, in main
    cli.command.execute(version='snactor version {}'.format(VERSION))
  File "/home/tmeszaro/work/github/leapp-actors/tut/lib/python2.7/site-packages/leapp/utils/clicmd.py", line 81, in execute
    args.func(args)
  File "/home/tmeszaro/work/github/leapp-actors/tut/lib/python2.7/site-packages/leapp/utils/clicmd.py", line 103, in called
    self.target(args)
  File "/home/tmeszaro/work/github/leapp-actors/tut/lib/python2.7/site-packages/leapp/utils/repository.py", line 20, in checker
    return f(*args, **kwargs)
  File "/home/tmeszaro/work/github/leapp-actors/tut/lib/python2.7/site-packages/leapp/snactor/context.py", line 11, in wrapper
    with get_connection(None) as db:
  File "/home/tmeszaro/work/github/leapp-actors/tut/lib/python2.7/site-packages/leapp/utils/audit/__init__.py", line 55, in get_connection
    return create_connection(cfg.get('database', 'path'))
  File "/home/tmeszaro/work/github/leapp-actors/tut/lib/python2.7/site-packages/leapp/utils/audit/__init__.py", line 42, in create_connection
    return _initialize_database(sqlite3.connect(path))
sqlite3.OperationalError: unable to open database file
```

Adding `leapp.conf` to repos that were missing it should solve the problem.