### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+**Before doing anything, please read
+[Leapp framework documentation](https://leapp.readthedocs.io/).**
+
+---
+
 # How to write actors
 
 See the tutorial for [creating the first actor](https://leapp.readthedocs.io/en/latest/first-actor.html).
@@ -6,7 +11,9 @@ See the tutorial for [creating the first actor](https://leapp.readthedocs.io/en/
 
 Please read documentation about [how to unit test actors](https://leapp.readthedocs.io/en/latest/unit-testing.html).
 
-## Actor dependencies
+# How to install dependencies, run tests & execute actors
+
+## Installing actor dependencies
 
 Each actor can now have its own Makefile with the `install-deps` target. This
 takes care of installing any dependencies of your actor. If your actor has
@@ -34,3 +41,27 @@ It is also possible to generate a report in a JUnit XML format:
 ``` bash
 $ make test REPORT=report.xml
 ```
+
+## Registering Leapp repositories and executing actors
+
+When you want to execute actor with
+
+``` bash
+$ snactor run my_actor
+```
+
+or run discover feature
+
+``` bash
+$ snactor discover
+```
+
+it is good idea to register everything in `repos` to avoid possible errors:
+
+```bash
+$ make register
+```
+where `register` target will run `snactor repo find --path repos`
+(you can verify if your repositories are registered in
+`~/.config/leapp/repos.json`).
+

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ or run discover feature
 $ snactor discover
 ```
 
-it is good idea to register everything in `repos` to avoid possible errors:
+it is good idea to register everything in `repos` to avoid possible errors
+with parsing repository metadata (**NOTE:** these errors can be sometimes
+cryptic, but may look like: `missing attribute name in .leapp/info`, etc.)
 
 ```bash
 $ make register

--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ To install dependencies for all actors, run:
 $ make install-deps
 ```
 
-For just one specific actor, run:
-
-``` bash
-$ make install-deps ACTOR=testactor
-```
-
 ## Running tests locally
 
 To run all tests from leapp-actors, run the following code from


### PR DESCRIPTION
- removed `ACTOR=my_actor` mention in `install-deps` target (no longer supported by `run_pytest.py`)
- added `register` target doc
- added link to main Leapp docs