### PR TITLE
ipu: Request first reboot instead

### DIFF
--- a/repos/upgrade/workflows/inplace_upgrade.py
+++ b/repos/upgrade/workflows/inplace_upgrade.py
@@ -62,7 +62,7 @@ class IPUWorkflow(Workflow):
         filter = TagFilter(InterimPreparationPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
-        flags = Flags(restart_after_phase=True)
+        flags = Flags(request_restart_after_phase=True)
 
     class InitRamStartPhase(Phase):
         name = 'InitRamStart'


### PR DESCRIPTION
Previously the reboot was executed automatically when
running the inplace upgrade workflow. This patch changes
the behaviour to request the reboot instead for the first
reboot.

Related-To: https://github.com/leapp-to/leapp/pull/366
Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>

**Requires https://github.com/leapp-to/leapp/pull/366 to be merged first!**